### PR TITLE
fix: reps missing a state causes rep-locator page to break

### DIFF
--- a/src/templates/page_store-locator.js
+++ b/src/templates/page_store-locator.js
@@ -16,8 +16,10 @@ import { formatPhoneNumber } from '../helpers/formatting'
 const groupRepsByState = reps => {
   const statesExtracted = reps.reduce((acc, { node }) => {
     const newNode = Object.assign({}, node)
-    newNode.states = newNode.states.length ? newNode.states[0].name : ''
-    acc.push(newNode)
+    if (newNode.states) {
+      newNode.states = newNode.states[0].name
+      acc.push(newNode)
+    }
     return acc
   }, [])
   const sortedReps = statesExtracted.sort((a, b) => {


### PR DESCRIPTION
![bitmoji](https://render.bitstrips.com/v2/cpanel/3d81f2e3-dec8-4395-a284-9c21f770a7e6-2aaeedac-bcbb-4874-b6db-f1b35bb0d614-v1.png?transparent=1&palette=1&width=246)